### PR TITLE
debian: replaced qt5-default with qtbase5-dev

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qamqp (0.5.0-bb3) unstable; urgency=low
+
+  * Replaced deprecated build dependency
+
+ -- Imre Steiner <imre.steiner@oneidentity.com>  Tue, 03 Dec 2024 13:27:03 +0000
+
 qamqp (0.5.0-bb2) unstable; urgency=low
 
   * Made auto reconnect work for basic#close errors

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qamqp
 Section: utils
 Priority: optional
 Maintainer: Robert Manner <robert.manner@balabit.com>
-Build-Depends: debhelper (>= 9), qt5-default
+Build-Depends: debhelper (>= 9), qtbase5-dev
 Standards-Version: 3.9.5
 Homepage: https://github.com/mbroadst/qamqp
 


### PR DESCRIPTION
qt5-default is no more.